### PR TITLE
Update SecureHeaders handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Here I am building the website for our Kinderladen Kila Hildegarten.
 
-The website is currently reachable through [https://kila-hildegarten.herokuapp.com/](https://kila-hildegarten.herokuapp.com/)
-
 The main website is: [https://kila-hildegarten.de](https://kila-hildegarten.de)
 
 ## Note
@@ -20,9 +18,9 @@ If they are enabled, the links will not work after first-time triggering.
 ## Technical Specifications
 
 - Security policies are managed via the **SecureHeaders** gem. Policies are controlled through `config/initializers/secure_headers.rb`.
-- The app is hosted on **Heroku**.
+- The app is hosted on [**Scalingo**](https://scalingo.com/). 
 - There is also an API connection to **Webling**.
-- **Redis** (Heroku Redis) is used to cache Webling photos for previews.
+- **Redis** (Scalingo Redis) is used to cache Webling photos for previews.
 - Photos are stored on **Dropbox**, using a custom Dropbox connection gem updated for current compatibility.
 
 ---
@@ -33,7 +31,7 @@ This repository contains the Ruby on Rails application for the **Kinderladen Kil
 It serves both the public website and an internal admin integration with [Webling](https://www.webling.eu/).
 
 🌐 **Production:** [https://kila-hildegarten.de](https://kila-hildegarten.de)
-🧪 **Staging (Heroku):** [https://kila-hildegarten.herokuapp.com](https://kila-hildegarten.herokuapp.com)
+🧪 **Staging (Scalingo):** [https://kila-hildegarten.osc-fr1.scalingo.io/](https://kila-hildegarten.osc-fr1.scalingo.io/)
 
 ---
 
@@ -43,9 +41,9 @@ The app provides a CMS-like interface. It allows admins to log in and update web
 
 For our Webling Kila management software, we use a secured page `/webling_photos` for managing photo previews, content pages, and member information synced from Webling.
 Only admins with the correct access token can access this page.
-It uses **Cloudinary** for asset storage and **Redis** caching for photo previews. Cloudinary is configured as a Heroku add-on.
+It uses **Cloudinary** for asset storage and **Redis** caching for photo previews.
 
-The stack is intentionally lightweight and optimized for hosting on **Heroku** with **Cloudflare** as CDN and SSL proxy.
+The stack is intentionally lightweight and optimized for hosting on **Scalingo** with **Cloudflare** as CDN and SSL proxy.
 
 ---
 
@@ -55,9 +53,9 @@ The stack is intentionally lightweight and optimized for hosting on **Heroku** w
 
 - **Ruby on Rails** (7.x)
 - **Ruby version:** specify your current version (e.g. `3.2.3`)
-- **Database:** PostgreSQL (Heroku managed)
-- **Cache:** Redis (Heroku Redis)
-- **Website Hosting:** Heroku
+- **Database:** PostgreSQL (Scalingo managed)
+- **Cache:** Redis (Scalingo Redis)
+- **Website Hosting:** Scalingo.com
 - **SSL:** via Cloudflare
 - **Domain:** managed via `one.com`
 
@@ -76,8 +74,8 @@ The stack is intentionally lightweight and optimized for hosting on **Heroku** w
 
 If assets 404 in production:
 ```bash
-heroku run rails assets:clobber
-heroku run rails assets:precompile
+scalingo --app kila-hildegarten run rails assets:clobber
+scalingo --app kila-hildegarten run rails assets:precompile
 ```
 
 ---
@@ -92,19 +90,22 @@ heroku run rails assets:precompile
 
 ### Security Headers (CSP)
 
-The app uses the **SecureHeaders** gem.
-Configuration is defined in `config/initializers/secure_headers.rb`.
+CSP and `X-Frame-Options` are managed manually in `config/application.rb` via
+`config.action_dispatch.default_headers` to avoid the SecureHeaders gem mangling `https://` URLs.
 
-**Key setting:**
+The SecureHeaders gem is still used for other minor security headers, but opts out of CSP
+and X-Frame-Options (`config/initializers/secure_headers.rb`).
+
+**Key iframe setting** — allows `/webling_photos` to be embedded in Webling:
 ```ruby
-img_src: %w('self' data: blob: https://*.dropboxusercontent.com https://res.cloudinary.com)
+"frame-ancestors 'self' https://hildegarten.webling.eu"
 ```
 
-This allows images to be loaded from:
-- Local assets (`'self'`)
-- Inline data URIs (`data:`)
-- ActiveStorage blob URLs (`blob:`)
-- Dropbox and Cloudinary
+If the iframe ever breaks again, check the actual headers first:
+```bash
+curl -I https://kila-hildegarten.de/
+```
+Look for `content-security-policy` and `x-frame-options` in the output.
 
 ---
 
@@ -158,17 +159,17 @@ The Kila Hildegarten app integrates several external services to deliver optimiz
                                     ▼
                       ┌───────────────────────────┐
                       │  Rails Application        │
-                      │  (Heroku)                 │
+                      │  (Scalingo)                 │
                       │                           │
                       │  • Fetches data from Webling
                       │  • Stores metadata in PostgreSQL
                       │  • Caches previews in Redis
-                      │  • Uses SecureHeaders for CSP
+                      │  • CSP managed via application.rb
                       │  • Serves assets via Asset Pipeline
                       └───────────┬────────────────┘
                                   │
        ActiveStorage              │          Cache Layer
-  (with Cloudinary adapter)       │          (Redis on Heroku)
+  (with Cloudinary adapter)       │          (Redis on Scalingo)
   ┌────────────────────────┐      │      ┌────────────────────┐
   │  Cloudinary CDN        │◄─────┼──────│  Redis              │
   │  Stores image variants │             │  Cached previews    │
@@ -211,7 +212,7 @@ The Kila Hildegarten app integrates several external services to deliver optimiz
 
 ## Key Features
 
-- **SecureHeaders** with custom CSP allows Dropbox and Cloudinary image sources.
+- CSP is managed manually in application.rb, allowing Dropbox and Cloudinary image sources.
 - **Resilient image loading** using lazy `data-src` and fallback placeholders.
 - **HTTPS enforcement** via Cloudflare and trusted proxy config.
 - **Lightweight integration** — Webling acts as backend data source.
@@ -237,18 +238,18 @@ bin/rails s -e production
 
 ## Deployment
 
-Deploy to Heroku:
+Deploy to Scalingo:
 
 ```bash
-git push heroku main
-heroku run rails db:migrate
+git push scalingo main
+scalingo --app kila-hildegarten run rails db:migrate
 ```
 
 Rebuild all assets:
 
 ```bash
-heroku run rails assets:clobber
-heroku run rails assets:precompile
+scalingo --app kila-hildegarten run rails assets:clobber
+scalingo --app kila-hildegarten run rails assets:precompile
 ```
 
 ---
@@ -257,12 +258,14 @@ heroku run rails assets:precompile
 
 | **Task** | **Command** |
 |-----------|-------------|
-| Clear cache | `heroku redis:cli --flushall` |
-| Rebuild assets | `heroku run rails assets:clobber && heroku run rails assets:precompile` |
-| Restart dynos | `heroku restart` |
-| Run database migrations | `heroku run rails db:migrate` |
-| Open Rails console | `heroku run rails c` |
-| Check logs | `heroku logs --tail` |
+| Clear Redis cache | `scalingo --app kila-hildegarten redis-console` → then type `FLUSHALL` |
+| Rebuild assets | `scalingo --app kila-hildegarten run rails assets:clobber && scalingo --app kila-hildegarten run rails assets:precompile` |
+| Restart app | `scalingo --app kila-hildegarten restart` |
+| Run database migrations | `scalingo --app kila-hildegarten run rails db:migrate` |
+| Open Rails console | `scalingo --app kila-hildegarten run rails console` |
+| Check logs | `scalingo --app kila-hildegarten logs -f` |
+| Check env variables | `scalingo --app kila-hildegarten env` |
+
 
 ---
 
@@ -271,8 +274,9 @@ heroku run rails assets:precompile
 | **Issue** | **Description** | **Solution** |
 |------------|-----------------|---------------|
 | Devise login redirects incorrectly (HTTP/HTTPS) | Cloudflare proxy affects request scheme | Use `config.force_ssl = true` and trust proxy headers |
-| Placeholder 404 | Asset pipeline not refreshed | Run `rails assets:clobber && rails assets:precompile` |
+| Placeholder 404 | Asset pipeline not refreshed | Run `scalingo --app kila-hildegarten run rails assets:clobber` and `scalingo --app kila-hildegarten run rails assets:precompile` |
 | Cloudinary images blocked | CSP restriction | Add `https://res.cloudinary.com` to `img_src` in `secure_headers.rb` |
+| iframe blocked in Webling | SecureHeaders gem strips `https://` from `frame-ancestors`, and `x-frame-options: sameorigin` also blocks embedding | CSP and X-Frame-Options are set manually in `application.rb`; do not move them back to `secure_headers.rb` |
 
 ---
 

--- a/app/services/webling_photo_cache_service.rb
+++ b/app/services/webling_photo_cache_service.rb
@@ -1,6 +1,6 @@
 # this class loads the photos from Webling via API and caches it permanently through ActiveStorage (Cloudinary)
 class WeblingPhotoCacheService
-  def initialize(photo_id:, api_key: Rails.application.credentials.dig(:webling, :api_key) || ENV["WEBLING_API_KEY"])
+  def initialize(photo_id:, api_key: ENV["WEBLING_API_KEY"] || Rails.application.credentials.dig(:webling, :api_key))
     @photo_id = photo_id
     @api_key  = api_key
   end

--- a/app/services/webling_photo_cache_service.rb
+++ b/app/services/webling_photo_cache_service.rb
@@ -1,6 +1,6 @@
 # this class loads the photos from Webling via API and caches it permanently through ActiveStorage (Cloudinary)
 class WeblingPhotoCacheService
-  def initialize(photo_id:, api_key: Rails.application.credentials.dig(:webling, :api_key))
+  def initialize(photo_id:, api_key: Rails.application.credentials.dig(:webling, :api_key) || ENV["WEBLING_API_KEY"])
     @photo_id = photo_id
     @api_key  = api_key
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,27 +1,37 @@
+# config/application.rb
 require_relative 'boot'
 require "logger"
 require "active_support/core_ext/numeric/time"
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module KilaHildegarten
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
     config.assets.initialize_on_precompile = false
     config.assets.check_precompiled_asset = false
 
-    # configure cloudflare to adjust the request header when redirecting from http to https
     require_relative '../lib/middleware/cloudflare'
     config.middleware.use Cloudflare
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    # Setting the secure headers manually to avoid issues with the secure_headers gem
+    # mangling URLs (stripping https://). This is the stable, low-maintenance approach.
+    config.action_dispatch.default_headers.merge!(
+      'X-Frame-Options'         => 'ALLOWFROM https://hildegarten.webling.eu',
+      'Content-Security-Policy' => [
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline'",
+        "connect-src 'self'",
+        "img-src 'self' data: blob: https://*.dropboxusercontent.com https://res.cloudinary.com",
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+        "font-src 'self' data: https://fonts.gstatic.com",
+        "frame-ancestors 'self' https://hildegarten.webling.eu",
+        "form-action 'self'",
+        "base-uri 'self'",
+        "frame-src 'self' https://hildegarten.webling.eu https://hildegarten.webling.ch https://www.openstreetmap.org"
+      ].join('; ')
+    )
   end
 end

--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,6 +1,4 @@
 if Rails.application.credentials.dig(:cloudinary, :url) || ENV["CLOUDINARY_URL"]
-  Cloudinary.config_from_url(
-    Rails.application.credentials.dig(:cloudinary, :url) || ENV["CLOUDINARY_URL"]
-  )
+  Cloudinary.config_from_url(ENV["CLOUDINARY_URL"] || Rails.application.credentials.dig(:cloudinary, :url))
   Cloudinary.config.secure = true
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,33 +1,9 @@
-# configure requests from other domains/websites
-# this is needed to allow incorporating a subpage as an iframe into webling
-if Rails.env.production?
-  SecureHeaders::Configuration.default do |config|
-    config.csp = {
-      default_src: %w('self'),
-      script_src: %w('self' 'unsafe-inline'),
-      connect_src: %w('self'),
-      img_src: %w('self' data: blob: https://*.dropboxusercontent.com https://res.cloudinary.com),
-      style_src: %w('self' 'unsafe-inline' https://fonts.googleapis.com),
-      font_src: %w('self' data: https://fonts.gstatic.com),
-      frame_ancestors: %w('self' https://hildegarten.webling.eu),
-      form_action: %w('self'),
-      base_uri: %w('self'),
-      frame_src: %w('self' https://hildegarten.webling.eu https://www.openstreetmap.org)
-    }
-  end
-else
-  SecureHeaders::Configuration.default do |config|
-    config.csp = {
-      default_src: %w('self'),
-      script_src: %w('self' 'unsafe-inline' 'unsafe-eval'),
-      connect_src: %w('self'),
-      img_src: %w('self' data: blob: https://*.dropboxusercontent.com https://res.cloudinary.com),
-      style_src: %w('self' 'unsafe-inline' https://fonts.googleapis.com),
-      font_src: %w('self' data: https://fonts.gstatic.com),
-      frame_ancestors: %w('self' https://hildegarten.webling.eu),
-      form_action: %w('self'),
-      base_uri: %w('self'),
-      frame_src: %w('self' https://hildegarten.webling.eu https://www.openstreetmap.org)
-    }
-  end
+# config/initializers/secure_headers.rb
+
+# CSP and X-Frame-Options are managed in config/application.rb
+# to avoid the secure_headers gem mangling https:// URLs.
+# This block only lets secure_headers manage the other minor security headers.
+SecureHeaders::Configuration.default do |config|
+  config.x_frame_options = SecureHeaders::OPT_OUT
+  config.csp = SecureHeaders::OPT_OUT
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -35,4 +35,4 @@ local:
 
 cloudinary:
   service: Cloudinary
-  url: <%= Rails.application.credentials.dig(:cloudinary, :url) || ENV["CLOUDINARY_URL"] %>
+  url: <%= ENV["CLOUDINARY_URL"] || Rails.application.credentials.dig(:cloudinary, :url)  %>


### PR DESCRIPTION
For some reason, I frequently get my iframe photo preview page blocked by secure headers. This PR aims on solving it to mange the secure headers directly in application.rb instead of the SecureHeaders gem. The gem seems to stripe away the https protocoll which leads to having the iframe being blocked.

This also updates the code to use the scalingo ENV instead of the rails credentials. It is also using the a new cloudinary account for the storage of the images. 